### PR TITLE
Group sensors by container device in monitor_docker

### DIFF
--- a/custom_components/monitor_docker/button.py
+++ b/custom_components/monitor_docker/button.py
@@ -10,6 +10,7 @@ from custom_components.monitor_docker.helpers import DockerAPI, DockerContainerA
 from homeassistant.components.button import ENTITY_ID_FORMAT, ButtonEntity
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -29,6 +30,8 @@ from .const import (
     CONF_BUTTONNAME,
     CONFIG,
     CONTAINER,
+    CONTAINER_INFO_IMAGE,
+    CONTAINER_INFO_IMAGE_HASH,
     CONTAINER_INFO_STATE,
     DOMAIN,
     SERVICE_RESTART,
@@ -181,6 +184,7 @@ class DockerContainerButton(ButtonEntity):
         self._instance = instance
         self._prefix = prefix
         self._cname = cname
+        self._alias = alias_name
         self._state = False
         self._entity_id = ENTITY_ID_FORMAT.format(
             slugify(self._prefix + "_" + self._cname + "_restart")
@@ -213,6 +217,18 @@ class DockerContainerButton(ButtonEntity):
     @property
     def is_on(self) -> bool:
         return self._state
+    @property
+    def device_info(self) -> DeviceInfo:
+        info = self._container.get_info()
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{self._instance}_{self._cname}")},
+            name=self._alias,
+            manufacturer="Docker",
+            model=info.get(CONTAINER_INFO_IMAGE),
+            sw_version=info.get(CONTAINER_INFO_IMAGE_HASH),
+            via_device=(DOMAIN, self._instance),
+        )
+
                                  
     async def async_press(self, **kwargs: Any) -> None:
         await self._container.restart()


### PR DESCRIPTION
## Summary
- group Docker host sensors under a device
- assign container entities to per-container devices
- describe devices with model, version and link back to the Docker host

## Testing
- `python3 -m py_compile custom_components/monitor_docker/sensor.py custom_components/monitor_docker/switch.py custom_components/monitor_docker/button.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a42855133c832b815ebd64d2da0b42