### PR TITLE
Add config flow and options for Monitor Docker

### DIFF
--- a/custom_components/monitor_docker/config_flow.py
+++ b/custom_components/monitor_docker/config_flow.py
@@ -1,0 +1,86 @@
+"""Config flow for Monitor Docker integration."""
+from __future__ import annotations
+
+from typing import Any
+
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_NAME, CONF_URL
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+
+from .const import (
+    DEFAULT_NAME,
+    DOMAIN,
+    CONF_CONTAINERS,
+    MONITORED_CONDITIONS_LIST,
+)
+
+
+class MonitorDockerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Monitor Docker."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+        """Handle the initial step."""
+        if user_input is not None:
+            return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_NAME, default=DEFAULT_NAME): str,
+                vol.Optional(CONF_URL): str,
+            }
+        )
+        return self.async_show_form(step_id="user", data_schema=data_schema)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:
+        return MonitorDockerOptionsFlow(config_entry)
+
+
+class MonitorDockerOptionsFlow(config_entries.OptionsFlow):
+    """Handle Monitor Docker options."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options for Monitor Docker."""
+        if user_input is not None:
+            containers = [
+                container.strip()
+                for container in user_input.get(CONF_CONTAINERS, "").split(",")
+                if container.strip()
+            ]
+            monitored = user_input.get(CONF_MONITORED_CONDITIONS, [])
+            return self.async_create_entry(
+                title="",
+                data={
+                    CONF_CONTAINERS: containers,
+                    CONF_MONITORED_CONDITIONS: monitored,
+                },
+            )
+
+        existing_containers = ", ".join(
+            self.config_entry.options.get(CONF_CONTAINERS, [])
+        )
+        existing_monitored = self.config_entry.options.get(
+            CONF_MONITORED_CONDITIONS, MONITORED_CONDITIONS_LIST
+        )
+
+        data_schema = vol.Schema(
+            {
+                vol.Optional(CONF_CONTAINERS, default=existing_containers): str,
+                vol.Optional(CONF_MONITORED_CONDITIONS, default=existing_monitored): cv.multi_select(
+                    MONITORED_CONDITIONS_LIST
+                ),
+            }
+        )
+
+        return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/custom_components/monitor_docker/manifest.json
+++ b/custom_components/monitor_docker/manifest.json
@@ -6,5 +6,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/ualex73/monitor_docker/issues",
   "requirements": ["aiodocker==0.24.0", "python-dateutil==2.9.0.post0"],
-  "version": "1.20b3"
+  "version": "1.20b3",
+  "config_flow": true
 }

--- a/custom_components/monitor_docker/strings.json
+++ b/custom_components/monitor_docker/strings.json
@@ -1,4 +1,28 @@
 {
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
+    },
     "services": {
         "reload": {
             "name": "[%key:common::action::reload%]",

--- a/custom_components/monitor_docker/translations/bg.json
+++ b/custom_components/monitor_docker/translations/bg.json
@@ -1,7 +1,31 @@
 {
     "services": {
         "restart": {
-            "name": "\u0420\u0435\u0441\u0442\u0430\u0440\u0442\u0438\u0440\u0430\u043d\u0435"
+            "name": "Рестартиране"
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
         }
     }
 }

--- a/custom_components/monitor_docker/translations/ca.json
+++ b/custom_components/monitor_docker/translations/ca.json
@@ -3,5 +3,29 @@
         "restart": {
             "name": "Reinicia"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/cs.json
+++ b/custom_components/monitor_docker/translations/cs.json
@@ -3,5 +3,29 @@
         "restart": {
             "name": "Restartovat"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/de.json
+++ b/custom_components/monitor_docker/translations/de.json
@@ -3,5 +3,29 @@
         "restart": {
             "name": "Neu starten"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/el.json
+++ b/custom_components/monitor_docker/translations/el.json
@@ -3,5 +3,29 @@
         "restart": {
             "name": "Restart"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/en.json
+++ b/custom_components/monitor_docker/translations/en.json
@@ -18,5 +18,29 @@
             },
             "name": "Restart"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/es.json
+++ b/custom_components/monitor_docker/translations/es.json
@@ -3,5 +3,29 @@
         "restart": {
             "name": "Reiniciar"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/et.json
+++ b/custom_components/monitor_docker/translations/et.json
@@ -1,7 +1,31 @@
 {
     "services": {
         "restart": {
-            "name": "Taask\u00e4ivita"
+            "name": "Taaskäivita"
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
         }
     }
 }

--- a/custom_components/monitor_docker/translations/fi.json
+++ b/custom_components/monitor_docker/translations/fi.json
@@ -1,7 +1,31 @@
 {
     "services": {
         "restart": {
-            "name": "Uudelleenk\u00e4ynnist\u00e4"
+            "name": "Uudelleenkäynnistä"
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
         }
     }
 }

--- a/custom_components/monitor_docker/translations/fr.json
+++ b/custom_components/monitor_docker/translations/fr.json
@@ -18,5 +18,29 @@
             },
             "name": "Redémarrer"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/he.json
+++ b/custom_components/monitor_docker/translations/he.json
@@ -1,7 +1,31 @@
 {
     "services": {
         "restart": {
-            "name": "\u05d4\u05e4\u05e2\u05dc\u05d4 \u05de\u05d7\u05d3\u05e9"
+            "name": "הפעלה מחדש"
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
         }
     }
 }

--- a/custom_components/monitor_docker/translations/hu.json
+++ b/custom_components/monitor_docker/translations/hu.json
@@ -1,7 +1,31 @@
 {
     "services": {
         "restart": {
-            "name": "\u00dajraind\u00edt\u00e1s"
+            "name": "Újraindítás"
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
         }
     }
 }

--- a/custom_components/monitor_docker/translations/id.json
+++ b/custom_components/monitor_docker/translations/id.json
@@ -3,5 +3,29 @@
         "restart": {
             "name": "Mulai Ulang"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/it.json
+++ b/custom_components/monitor_docker/translations/it.json
@@ -3,5 +3,29 @@
         "restart": {
             "name": "Riavvia"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/ja.json
+++ b/custom_components/monitor_docker/translations/ja.json
@@ -1,7 +1,31 @@
 {
     "services": {
         "restart": {
-            "name": "\u518d\u8d77\u52d5"
+            "name": "再起動"
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
         }
     }
 }

--- a/custom_components/monitor_docker/translations/ko.json
+++ b/custom_components/monitor_docker/translations/ko.json
@@ -1,7 +1,31 @@
 {
     "services": {
         "restart": {
-            "name": "\uc7ac\uc2dc\uc791"
+            "name": "재시작"
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
         }
     }
 }

--- a/custom_components/monitor_docker/translations/lt.json
+++ b/custom_components/monitor_docker/translations/lt.json
@@ -3,5 +3,29 @@
         "restart": {
             "name": "Perkrauti"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/nb.json
+++ b/custom_components/monitor_docker/translations/nb.json
@@ -3,5 +3,29 @@
         "restart": {
             "name": "Omstart"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/nl.json
+++ b/custom_components/monitor_docker/translations/nl.json
@@ -18,5 +18,29 @@
             },
             "name": "Herstarten"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/pl.json
+++ b/custom_components/monitor_docker/translations/pl.json
@@ -3,5 +3,29 @@
         "restart": {
             "name": "Uruchom ponownie"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/pt-BR.json
+++ b/custom_components/monitor_docker/translations/pt-BR.json
@@ -3,5 +3,29 @@
         "restart": {
             "name": "Reiniciar"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/pt.json
+++ b/custom_components/monitor_docker/translations/pt.json
@@ -3,5 +3,29 @@
         "restart": {
             "name": "Reiniciar"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/ru.json
+++ b/custom_components/monitor_docker/translations/ru.json
@@ -1,7 +1,31 @@
 {
     "services": {
         "restart": {
-            "name": "\u041f\u0435\u0440\u0435\u0437\u0430\u043f\u0443\u0441\u0442\u0438\u0442\u044c"
+            "name": "Перезапустить"
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
         }
     }
 }

--- a/custom_components/monitor_docker/translations/sk.json
+++ b/custom_components/monitor_docker/translations/sk.json
@@ -1,7 +1,31 @@
 {
     "services": {
         "restart": {
-            "name": "Re\u0161tart"
+            "name": "Reštart"
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
         }
     }
 }

--- a/custom_components/monitor_docker/translations/sv.json
+++ b/custom_components/monitor_docker/translations/sv.json
@@ -3,5 +3,29 @@
         "restart": {
             "name": "Starta om"
         }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
+        }
     }
 }

--- a/custom_components/monitor_docker/translations/tr.json
+++ b/custom_components/monitor_docker/translations/tr.json
@@ -1,7 +1,31 @@
 {
     "services": {
         "restart": {
-            "name": "Yeniden ba\u015flat"
+            "name": "Yeniden başlat"
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
         }
     }
 }

--- a/custom_components/monitor_docker/translations/zh-Hans.json
+++ b/custom_components/monitor_docker/translations/zh-Hans.json
@@ -1,7 +1,31 @@
 {
     "services": {
         "restart": {
-            "name": "\u91cd\u65b0\u5f00\u59cb"
+            "name": "重新开始"
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
         }
     }
 }

--- a/custom_components/monitor_docker/translations/zh-Hant.json
+++ b/custom_components/monitor_docker/translations/zh-Hant.json
@@ -1,7 +1,31 @@
 {
     "services": {
         "restart": {
-            "name": "\u91cd\u65b0\u958b\u59cb"
+            "name": "重新開始"
+        }
+    },
+    "config": {
+        "step": {
+            "user": {
+                "title": "Monitor Docker",
+                "description": "Set up Monitor Docker integration.",
+                "data": {
+                    "name": "Name",
+                    "url": "Docker URL"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Monitor Docker options",
+                "description": "Edit monitored containers and conditions.",
+                "data": {
+                    "containers": "Containers to monitor",
+                    "monitored_conditions": "Monitored conditions"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Home Assistant config flow and options flow for Monitor Docker
- enable config flow in manifest
- add translations for new flows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a48839e5f4832bb7cd45b725fd9967