### PR TITLE
feat: register docker containers as devices

### DIFF
--- a/custom_components/monitor_docker/button.py
+++ b/custom_components/monitor_docker/button.py
@@ -15,6 +15,8 @@ from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import slugify
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceEntryType, async_get as async_get_dev_reg
 
 from .const import (
     API,
@@ -30,6 +32,8 @@ from .const import (
     CONFIG,
     CONTAINER,
     CONTAINER_INFO_STATE,
+    CONTAINER_INFO_IMAGE,
+    CONTAINER_INFO_IMAGE_HASH,
     DOMAIN,
     SERVICE_RESTART,
 )
@@ -155,6 +159,21 @@ async def async_setup_platform(
         _LOGGER.info("[%s]: No containers set-up", instance)
         return False
 
+    entity_registry = er.async_get(hass)
+    device_registry = async_get_dev_reg(hass)
+    for entity in buttons:
+        if (entry := entity_registry.async_get(entity.entity_id)) and not entry.unique_id:
+            device = device_registry.async_get_device(
+                entity.device_info["identifiers"], set()
+            )
+            if device is None:
+                device = device_registry.async_get_or_create(
+                    config_entry_id=None, **entity.device_info
+                )
+            entity_registry.async_update_entity(
+                entry.entity_id, new_unique_id=entity.unique_id, device_id=device.id
+            )
+
     async_add_entities(buttons, True)
 
     # platform = entity_platform.current_platform.get()
@@ -187,6 +206,22 @@ class DockerContainerButton(ButtonEntity):
         )
         self._name = name_format.format(name=alias_name)
         self._removed = False
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._container.get_id()}_restart"
+
+    @property
+    def device_info(self) -> dict:
+        info = self._container.get_info()
+        return {
+            "identifiers": {(DOMAIN, self._container.get_id())},
+            "name": self._cname,
+            "manufacturer": "Docker",
+            "model": info.get(CONTAINER_INFO_IMAGE),
+            "sw_version": info.get(CONTAINER_INFO_IMAGE_HASH),
+            "entry_type": DeviceEntryType.SERVICE,
+        }
 
     @property
     def entity_id(self) -> str:

--- a/custom_components/monitor_docker/button.py
+++ b/custom_components/monitor_docker/button.py
@@ -6,7 +6,7 @@ import re
 from typing import Any
 
 import voluptuous as vol
-from custom_components.monitor_docker.helpers import DockerAPI, DockerContainerAPI
+from .helpers import DockerAPI, DockerContainerAPI
 from homeassistant.components.button import ENTITY_ID_FORMAT, ButtonEntity
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -162,6 +162,18 @@ async def async_setup_platform(
     entity_registry = er.async_get(hass)
     device_registry = async_get_dev_reg(hass)
     for entity in buttons:
+        old_unique_id = f"{entity._cname}_restart"
+        if entity_id := entity_registry.async_get_entity_id(
+            "button", DOMAIN, old_unique_id
+        ):
+            entry = entity_registry.async_get(entity_id)
+            device = device_registry.async_get_or_create(
+                config_entry_id=None, **entity.device_info
+            )
+            entity_registry.async_update_entity(
+                entry.entity_id, new_unique_id=entity.unique_id, device_id=device.id
+            )
+            continue
         if (entry := entity_registry.async_get(entity.entity_id)) and not entry.unique_id:
             device = device_registry.async_get_device(
                 entity.device_info["identifiers"], set()

--- a/custom_components/monitor_docker/helpers.py
+++ b/custom_components/monitor_docker/helpers.py
@@ -22,6 +22,10 @@ from homeassistant.const import (
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers.discovery import load_platform
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.device_registry import (
+    DeviceEntryType,
+    async_get as async_get_dev_reg,
+)
 
 from .const import (
     ATTR_MEMORY_LIMIT,
@@ -99,6 +103,7 @@ class DockerAPI:
         self._containers: dict[str, DockerContainerAPI] = {}
         self._tasks: dict[str, asyncio.Task] = {}
         self._info: dict[str, Any] = {}
+        self._host_id: str | None = None
         self._event_create: dict[str, int] = {}
         self._event_destroy: dict[str, int] = {}
         self._dockerStopped = False
@@ -224,6 +229,20 @@ class DockerAPI:
         versionInfo = await self._api.version()
         version: str | None = versionInfo.get("Version", None)
 
+        # Retrieve host information for device registration
+        host_info = await self._api.system.info()
+        self._host_id = host_info.get("ID")
+        device_registry = async_get_dev_reg(self._hass)
+        device_registry.async_get_or_create(
+            config_entry_id=None,
+            identifiers={(DOMAIN, self._host_id)},
+            manufacturer="Docker",
+            name=self._instance,
+            model=host_info.get("OperatingSystem"),
+            sw_version=version,
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
         # Pre 19.03 support memory calculation is dropped
         _LOGGER.debug("[%s]: Docker version: %s", self._instance, version)
 
@@ -239,6 +258,20 @@ class DockerAPI:
         for container in containers or []:
             # Determine name from Docker API, it contains an array with a slash
             cname: str = container._container["Names"][0][1:]
+            cid: str = container._container.get("Id")
+
+            image = container._container.get("Image")
+            image_id = container._container.get("ImageID")
+
+            device_registry.async_get_or_create(
+                config_entry_id=None,
+                identifiers={(DOMAIN, cid)},
+                manufacturer="Docker",
+                name=cname,
+                model=image,
+                sw_version=image_id,
+                entry_type=DeviceEntryType.SERVICE,
+            )
 
             # We will monitor all containers, including excluded ones.
             # This is needed to get total CPU/Memory usage.
@@ -249,6 +282,7 @@ class DockerAPI:
                 self._config,
                 self._api,
                 cname,
+                cid,
             )
             await self._containers[cname].init()
 
@@ -576,9 +610,31 @@ class DockerAPI:
 
         _LOGGER.debug("[%s] %s: Starting Container Monitor", self._instance, cname)
 
+        # Fetch container information to register the device
+        try:
+            container = await self._api.containers.get(cname)
+            raw = await container.show()
+            cid = raw.get("Id")
+            image = raw.get("Config", {}).get("Image")
+            image_id = raw.get("Image")
+        except Exception as err:
+            _LOGGER.error("[%s] %s: Failed to get container info (%s)", self._instance, cname, err)
+            return
+
+        device_registry = async_get_dev_reg(self._hass)
+        device_registry.async_get_or_create(
+            config_entry_id=None,
+            identifiers={(DOMAIN, cid)},
+            manufacturer="Docker",
+            name=cname,
+            model=image,
+            sw_version=image_id,
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
         # Create our Docker Container API
         self._containers[cname] = DockerContainerAPI(
-            self._config, self._api, cname, atInit=False
+            self._config, self._api, cname, cid, atInit=False
         )
 
         # We should wait until container is attached
@@ -808,6 +864,10 @@ class DockerAPI:
             return None
 
     #############################################################
+    def get_host_id(self) -> str | None:
+        return self._host_id
+
+    #############################################################
     def get_info(self) -> dict[str, Any]:
         return self._info
 
@@ -821,6 +881,7 @@ class DockerContainerAPI:
         config: ConfigType,
         api: aiodocker.Docker,
         cname: str,
+        cid: str,
         atInit=True,
     ):
         self._config = config
@@ -828,6 +889,7 @@ class DockerContainerAPI:
         self._instance: str = config[CONF_NAME]
         self._memChange: int = config[CONF_MEMORYCHANGE]
         self._name = cname
+        self._id = cid
         self._interval: int = config[CONF_SCAN_INTERVAL].seconds
         self._retry_interval: int = config[CONF_RETRY]
         self._busy = False
@@ -846,6 +908,9 @@ class DockerContainerAPI:
 
         self._info: dict[str, Any] = {}
         self._stats: dict[str, Any] = {}
+
+    def get_id(self) -> str:
+        return self._id
 
     async def init(self):
         # During start-up we will wait on container attachment,

--- a/custom_components/monitor_docker/sensor.py
+++ b/custom_components/monitor_docker/sensor.py
@@ -197,6 +197,21 @@ async def async_setup_platform(
     entity_registry = er.async_get(hass)
     device_registry = async_get_dev_reg(hass)
     for entity in sensors:
+        if isinstance(entity, DockerContainerSensor):
+            old_unique_id = f"{entity._cname}_{entity.entity_description.key}"
+            if entity_id := entity_registry.async_get_entity_id(
+                "sensor", DOMAIN, old_unique_id
+            ):
+                entry = entity_registry.async_get(entity_id)
+                device = device_registry.async_get_or_create(
+                    config_entry_id=None, **entity.device_info
+                )
+                entity_registry.async_update_entity(
+                    entry.entity_id,
+                    new_unique_id=entity.unique_id,
+                    device_id=device.id,
+                )
+                continue
         if (entry := entity_registry.async_get(entity.entity_id)) and not entry.unique_id:
             device = device_registry.async_get_device(
                 entity.device_info["identifiers"], set()

--- a/custom_components/monitor_docker/switch.py
+++ b/custom_components/monitor_docker/switch.py
@@ -15,6 +15,8 @@ from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import slugify
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import DeviceEntryType, async_get as async_get_dev_reg
 
 from .const import (
     API,
@@ -30,6 +32,8 @@ from .const import (
     CONFIG,
     CONTAINER,
     CONTAINER_INFO_STATE,
+    CONTAINER_INFO_IMAGE,
+    CONTAINER_INFO_IMAGE_HASH,
     DOMAIN,
     SERVICE_RESTART,
 )
@@ -155,6 +159,21 @@ async def async_setup_platform(
         _LOGGER.info("[%s]: No containers set-up", instance)
         return False
 
+    entity_registry = er.async_get(hass)
+    device_registry = async_get_dev_reg(hass)
+    for entity in switches:
+        if (entry := entity_registry.async_get(entity.entity_id)) and not entry.unique_id:
+            device = device_registry.async_get_device(
+                entity.device_info["identifiers"], set()
+            )
+            if device is None:
+                device = device_registry.async_get_or_create(
+                    config_entry_id=None, **entity.device_info
+                )
+            entity_registry.async_update_entity(
+                entry.entity_id, new_unique_id=entity.unique_id, device_id=device.id
+            )
+
     async_add_entities(switches, True)
 
     # platform = entity_platform.current_platform.get()
@@ -188,6 +207,22 @@ class DockerContainerSwitch(SwitchEntity):
         )
         self._name = name_format.format(name=alias_name)
         self._removed = False
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._container.get_id()}_switch"
+
+    @property
+    def device_info(self) -> dict:
+        info = self._container.get_info()
+        return {
+            "identifiers": {(DOMAIN, self._container.get_id())},
+            "name": self._cname,
+            "manufacturer": "Docker",
+            "model": info.get(CONTAINER_INFO_IMAGE),
+            "sw_version": info.get(CONTAINER_INFO_IMAGE_HASH),
+            "entry_type": DeviceEntryType.SERVICE,
+        }
 
     @property
     def entity_id(self) -> str:


### PR DESCRIPTION
## Summary
- create device registry entries for Docker hosts and containers using container IDs
- expose stable unique IDs and device info for container sensors, switches, and buttons
- migrate existing entity registry entries to new container-based unique IDs and devices

## Testing
- `python -m py_compile custom_components/monitor_docker/{__init__,helpers,sensor,switch,button}.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8852676fc832b8c29031832a80494